### PR TITLE
Fix detection script

### DIFF
--- a/bin/detect
+++ b/bin/detect
@@ -1,3 +1,4 @@
 #!/usr/bin/env bash
 
+echo "MaxMind GeoIP Database Installer"
 exit 0 # should always run


### PR DESCRIPTION
Heroku requires the name of the buildpack to be printed to stdout during detection.

This simple PR fixes that. Thanks to @ojacobson for the tip on the issue.
